### PR TITLE
Allow simulating typing for private channels

### DIFF
--- a/DiscordSharp/DiscordClient.cs
+++ b/DiscordSharp/DiscordClient.cs
@@ -1034,7 +1034,7 @@ namespace DiscordSharp
         /// -A message is sent
         /// </summary>
         /// <param name="channel"></param>
-        public void SimulateTyping(DiscordChannel channel)
+        public void SimulateTyping(DiscordChannelBase channel)
         {
             string url = Endpoints.BaseAPI + Endpoints.Channels + $"/{channel.ID}" + Endpoints.Typing;
             try


### PR DESCRIPTION
Switch to using DiscordChannelBase for SimulateTyping since the only thing that gets used is the ID, and I've confirmed the API works fine with this.
